### PR TITLE
Check PtyReceived for null before invoking

### DIFF
--- a/FxSsh/Services/ConnectionService.cs
+++ b/FxSsh/Services/ConnectionService.cs
@@ -163,7 +163,7 @@ namespace FxSsh.Services
         {
             var channel = FindChannelByServerId<SessionChannel>(message.RecipientChannel);
 
-            PtyReceived.Invoke(this,
+            PtyReceived?.Invoke(this,
                 new PtyArgs(channel,
                     message.Terminal,
                     message.heightPx,


### PR DESCRIPTION
`PtyReceived` event was not being null-checked before invoking, so would throw if `PtyReceived` event wasn't handled