### PR TITLE
Add event for "window-change" (shell resize) message

### DIFF
--- a/FxSsh/Messages/Connection/WindowChangeMessage.cs
+++ b/FxSsh/Messages/Connection/WindowChangeMessage.cs
@@ -1,0 +1,20 @@
+﻿namespace FxSsh.Messages.Connection
+{
+    public class WindowChangeMessage : ChannelRequestMessage
+    {
+        public uint widthChars = 0;
+        public uint heightRows = 0;
+        public uint widthPx = 0;
+        public uint heightPx = 0;
+
+        protected override void OnLoad(SshDataWorker reader)
+        {
+            base.OnLoad(reader);
+
+            widthChars = reader.ReadUInt32();
+            heightRows = reader.ReadUInt32();
+            widthPx = reader.ReadUInt32();
+            heightPx = reader.ReadUInt32();
+        }
+    }
+}

--- a/FxSsh/Services/WindowResizedArgs.cs
+++ b/FxSsh/Services/WindowResizedArgs.cs
@@ -1,0 +1,28 @@
+﻿using System.Diagnostics.Contracts;
+
+namespace FxSsh.Services
+{
+    public class WindowResizedArgs
+    {
+        public WindowResizedArgs(SessionChannel channel, uint heightPx, uint heightRows, uint widthPx, uint widthChars, UserauthArgs userauthArgs)
+        {
+            Contract.Requires(channel != null);
+            Contract.Requires(userauthArgs != null);
+
+            Channel = channel;
+            HeightPx = heightPx;
+            HeightRows = heightRows;
+            WidthPx = widthPx;
+            WidthChars = widthChars;
+
+            AttachedUserauthArgs = userauthArgs;
+        }
+
+        public SessionChannel Channel { get; private set; }
+        public uint HeightPx { get; private set; }
+        public uint HeightRows { get; private set; }
+        public uint WidthPx { get; private set; }
+        public uint WidthChars { get; private set; }
+        public UserauthArgs AttachedUserauthArgs { get; private set; }
+    }
+}

--- a/SshServerLoader/Program.cs
+++ b/SshServerLoader/Program.cs
@@ -57,7 +57,13 @@ namespace SshServerLoader
                 service.EnvReceived += service_EnvReceived;
                 service.PtyReceived += service_PtyReceived;
                 service.TcpForwardRequest += service_TcpForwardRequest;
+                service.WindowResized += service_WindowResized;
             }
+        }
+
+        private static void service_WindowResized(object sender, WindowResizedArgs e)
+        {
+            Console.WriteLine("Received a window resize notification: {0}x{1} chars", e.WidthChars, e.HeightRows);
         }
 
         static void service_TcpForwardRequest(object sender, TcpRequestArgs e)


### PR DESCRIPTION
Implements [RFC4254 6.7](https://tools.ietf.org/html/rfc4254#section-6.7). Adds a callback for the "window-change" message, so the server can redraw if necessary after the client resizes the ssh client window. 
@Aimeast 