### PR TITLE
Implementing SSH_MSG_EXT_INFO (RFC8308)

### DIFF
--- a/FxSsh/Messages/ExtInfoMessage.cs
+++ b/FxSsh/Messages/ExtInfoMessage.cs
@@ -1,0 +1,39 @@
+﻿using System.Collections.Generic;
+using System.Text;
+
+namespace FxSsh.Messages
+{
+    [Message("SSH_MSG_EXT_INFO", MessageNumber)]
+    public class ExtInfoMessage : Message
+    {
+        private const byte MessageNumber = 7;
+        internal const string ServerSignatureAlgorithms = "server-sig-algs";
+        internal const string ExtendedInfoClient = "ext-info-c";
+
+        public override byte MessageType { get { return MessageNumber; } }
+
+        public Dictionary<string, string> Extensions { get; private set; } = new();
+
+        protected override void OnGetPacket(SshDataWriter writer)
+        {
+            writer.Write((uint)Extensions.Count);
+            foreach (var kvp in Extensions)
+            {
+                writer.Write(kvp.Key, Encoding.ASCII);
+                writer.Write(kvp.Value, Encoding.ASCII);
+            }
+        }
+
+        protected override void OnLoad(SshDataReader reader)
+        {
+            var count = reader.ReadUInt32();
+            Extensions = new Dictionary<string, string>((int)count);
+            for (uint i = 0; i < count; i++)
+            {
+                var key = reader.ReadString(Encoding.ASCII);
+                var value = reader.ReadString(Encoding.ASCII);
+                Extensions.Add(key, value);
+            }
+        }
+    }
+}

--- a/FxSsh/Messages/KeyExchangeInitMessage.cs
+++ b/FxSsh/Messages/KeyExchangeInitMessage.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 
@@ -39,6 +40,8 @@ namespace FxSsh.Messages
         public bool FirstKexPacketFollows { get; set; }
 
         public uint Reserved { get; set; }
+
+        public bool CanSendExtInfo => KeyExchangeAlgorithms.Contains(ExtInfoMessage.ExtendedInfoClient, StringComparer.OrdinalIgnoreCase);
 
         public override byte MessageType { get { return MessageNumber; } }
 

--- a/FxSsh/Services/KeyExchangeArgs.cs
+++ b/FxSsh/Services/KeyExchangeArgs.cs
@@ -35,5 +35,7 @@ namespace FxSsh.Services
         public string[] LanguagesClientToServer { get; set; }
 
         public string[] LanguagesServerToClient { get; set; }
+
+        public bool CanSendExtInfo { get; set; }
     }
 }

--- a/FxSsh/Session.cs
+++ b/FxSsh/Session.cs
@@ -513,7 +513,8 @@ namespace FxSsh
                 LanguagesServerToClient = message.LanguagesServerToClient,
                 MacAlgorithmsClientToServer = message.MacAlgorithmsClientToServer,
                 MacAlgorithmsServerToClient = message.MacAlgorithmsServerToClient,
-                ServerHostKeyAlgorithms = message.ServerHostKeyAlgorithms
+                ServerHostKeyAlgorithms = message.ServerHostKeyAlgorithms,
+                CanSendExtInfo = message.CanSendExtInfo
             });
 
             _exchangeContext.KeyExchange = ChooseAlgorithm([.. _keyExchangeAlgorithms.Keys], message.KeyExchangeAlgorithms);
@@ -524,6 +525,7 @@ namespace FxSsh
             _exchangeContext.ServerHmac = ChooseAlgorithm([.. _hmacAlgorithms.Keys], message.MacAlgorithmsServerToClient);
             _exchangeContext.ClientCompression = ChooseAlgorithm([.. _compressionAlgorithms.Keys], message.CompressionAlgorithmsClientToServer);
             _exchangeContext.ServerCompression = ChooseAlgorithm([.. _compressionAlgorithms.Keys], message.CompressionAlgorithmsServerToClient);
+            _exchangeContext.CanSendExtInfo = message.CanSendExtInfo;
 
             _exchangeContext.ClientKexInitPayload = message.GetPacket();
         }
@@ -611,6 +613,13 @@ namespace FxSsh
 
         private void HandleMessage(NewKeysMessage message)
         {
+            if (_exchangeContext.CanSendExtInfo)
+            {
+                var extInfo = new ExtInfoMessage();
+                extInfo.Extensions.Add(ExtInfoMessage.ServerSignatureAlgorithms, string.Join(",", _publicKeyAlgorithms.Keys));
+                SendMessage(extInfo);
+            }
+            
             _hasBlockedMessagesWaitHandle.Reset();
 
             lock (_locker)
@@ -810,6 +819,7 @@ namespace FxSsh
             public byte[] ServerKexInitPayload;
 
             public Algorithms NewAlgorithms;
+            public bool CanSendExtInfo;
         }
     }
 }


### PR DESCRIPTION
Adds support for https://datatracker.ietf.org/doc/html/rfc8308 (server side only though)

When support for RFC8332 was added, the point [3.3](https://datatracker.ietf.org/doc/html/rfc8332#section-3.3) was probably skipped since it's a _**SHOULD**_ . 

> **Discovery of Public Key Algorithms Supported by Servers**
>
> Implementation experience has shown that there are servers that apply
   authentication penalties to clients attempting public key algorithms
   that the SSH server does not support.
>
> Servers that accept rsa-sha2-* signatures for client authentication
   SHOULD implement the extension negotiation mechanism defined in
   [[RFC8308](https://datatracker.ietf.org/doc/html/rfc8308)], including especially the "server-sig-algs" extension.
>
> When authenticating with an RSA key against a server that does not
   implement the "server-sig-algs" extension, clients MAY default to an
   "ssh-rsa" signature to avoid authentication penalties.  When the new
   rsa-sha2-* algorithms have been sufficiently widely adopted to
   warrant disabling "ssh-rsa", clients MAY default to one of the new
   algorithms.

This PR addresses that and RSA keys are working as expected. This resolves https://github.com/Aimeast/FxSsh/issues/49